### PR TITLE
Add support for background scripts in Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ The boilerplate contains 2 manifest files: an extension manifest for Google Chro
 
 The `build` folder will contain either of them depending on which build script you run - `yarn build:extension` or `yarn build:web-app`
 
+### Background scripts
+
+If your Chrome extension needs to use background scripts, add them to `src/background/index.ts`.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -67,9 +67,16 @@ module.exports = {
       // https://symfonycasts.com/screencast/webpack-encore/single-runtime-chunk
       config.optimization.runtimeChunk = false;
 
-      // The name of the extension bundle must not include `[contenthash]`,
-      // so it can be referenced in `manifest.json` as `content_script`.
-      config.output.filename = "main.js";
+      config.entry = {
+        // web extension
+        main: "./src/index.tsx",
+        // background script that has to be referenced in the extension manifest
+        background: "./src/background/index.ts",
+      };
+
+      // Filenames of bundles must not include `[contenthash]`, so that they can be referenced in `extension-manifest.json`.
+      // The `[name]` is taken from `config.entry` properties, so if we have `main` and `background` as properties, we get 2 output files - main.js and background.js.
+      config.output.filename = "[name].js";
 
       // `MiniCssExtractPlugin` is used by the default CRA webpack configuration for
       // extracting CSS into separate files. The plugin has to be removed because it

--- a/public/extension-manifest.json
+++ b/public/extension-manifest.json
@@ -16,5 +16,9 @@
       "css": ["main.css"]
     }
   ],
-  "web_accessible_resources": ["static/*"]
+  "web_accessible_resources": ["static/*"],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  }
 }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,0 +1,10 @@
+// A basic example how you can use background scripts in your Chrome extension.
+// More on: https://developer.chrome.com/docs/extensions/mv2/background_pages/.
+
+window.chrome.runtime.onInstalled.addListener(() => {
+  console.log(
+    "'Create React Chrome Extension - TypeScript' installed/updated..."
+  );
+});
+
+export default {};


### PR DESCRIPTION
- updates webpack configuration so that background scripts are compiled to a separate bundle
- generated background scripts are registered in the extension manifest
- a basic example with a background script is added